### PR TITLE
Fix compatibility with maven artifacts

### DIFF
--- a/src/main/groovy/com/ullink/gradle/plugins/jibx/JIBXPlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/plugins/jibx/JIBXPlugin.groovy
@@ -112,12 +112,7 @@ class JIBXPlugin implements Plugin<Project> {
                     include project.JIBXBinding.rootAPIPath+'/**/*.*'
                 }
 
-                if (project.JIBXBinding.unboundJarName) {
-                    archiveName = project.JIBXBinding.unboundJarName
-                }
-                generateUnboundJar.onlyIf {
-                    project.JIBXBinding.unboundJarName != null
-                }
+                generateUnboundJar.onlyIf { project.JIBXBinding.archiveUnboundJar }
                 // hooking JIBX on "classes" task from java plugin
                 project.getTasks().getByName('classes').dependsOn('postJIBX')
 

--- a/src/main/groovy/com/ullink/gradle/plugins/jibx/JIBXPlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/plugins/jibx/JIBXPlugin.groovy
@@ -17,6 +17,14 @@ class JIBXPlugin implements Plugin<Project> {
         //force cleanup since incremental build on this plugin is not yet working well
         project.sourceSets.main.output.classesDir.deleteDir();
 
+        def generateUnboundJar = project.task(type: Jar, dependsOn: 'JIBXResources', 'generateUnboundJar') {
+            classifier = 'nojibxbinding'
+            if (project.JIBXBinding.unboundJarName !=null) {
+                archiveName = project.JIBXBinding.unboundJarName
+            }
+            from project.sourceSets.main.output.files
+        }
+
         project.configure(project) {
             afterEvaluate {
 
@@ -107,13 +115,6 @@ class JIBXPlugin implements Plugin<Project> {
                     include project.JIBXBinding.rootAPIPath+'/**/*.*'
                 }
 
-                def generateUnboundJar = project.task(type: Jar, dependsOn: 'JIBXResources', 'generateUnboundJar') {
-                    appendix = 'nojibxbinding'
-                    if (project.JIBXBinding.unboundJarName !=null) {
-                        archiveName = project.JIBXBinding.unboundJarName
-                    }
-                    from project.sourceSets.main.output.files
-                }
 
                 generateUnboundJar.onlyIf {
                     project.JIBXBinding.unboundJarName != null

--- a/src/main/groovy/com/ullink/gradle/plugins/jibx/JIBXPlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/plugins/jibx/JIBXPlugin.groovy
@@ -19,9 +19,6 @@ class JIBXPlugin implements Plugin<Project> {
 
         def generateUnboundJar = project.task(type: Jar, dependsOn: 'JIBXResources', 'generateUnboundJar') {
             classifier = 'nojibxbinding'
-            if (project.JIBXBinding.unboundJarName !=null) {
-                archiveName = project.JIBXBinding.unboundJarName
-            }
             from project.sourceSets.main.output.files
         }
 
@@ -115,7 +112,9 @@ class JIBXPlugin implements Plugin<Project> {
                     include project.JIBXBinding.rootAPIPath+'/**/*.*'
                 }
 
-
+                if (project.JIBXBinding.unboundJarName) {
+                    archiveName = project.JIBXBinding.unboundJarName
+                }
                 generateUnboundJar.onlyIf {
                     project.JIBXBinding.unboundJarName != null
                 }

--- a/src/main/groovy/com/ullink/gradle/plugins/jibx/JIBXPluginExtension.groovy
+++ b/src/main/groovy/com/ullink/gradle/plugins/jibx/JIBXPluginExtension.groovy
@@ -16,7 +16,7 @@ class JIBXPluginExtension {
     def boolean skipBindValidation = false
     def boolean trackBranches = false
     def boolean testLoading = false
-    def String unboundJarName = null
+    def boolean archiveUnboundJar = false
 
     def Map<String, String> JIBXExternalJars = new HashMap<>();
 


### PR DESCRIPTION
- make generateUndoundJar task accessible from project config
  example : 
  artifacts{
  archives generateUnboundTask
  }
- add classifier to be able to upload generated jar into a repo
