### PR TITLE
Make jibx plugin compatible with gradle 5

### DIFF
--- a/src/main/groovy/com/ullink/gradle/plugins/jibx/JIBXPlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/plugins/jibx/JIBXPlugin.groovy
@@ -14,7 +14,7 @@ class JIBXPlugin implements Plugin<Project> {
         def output = project.sourceSets.main.output
         def mainClassesDirs
         if (output.hasProperty('classesDirs')) {
-            mainClassesDirs = output.classesDirs
+            mainClassesDirs = output.classesDirs.getSingleFile()
         } else {
             mainClassesDirs = output.classesDir
         }


### PR DESCRIPTION
- since gradle 5 classesDirs is not anymore a File but
instead a FileCollection
- assert and get only the first directory (reasoning is
till today we had only one source project, if we need
multiple source this needs to be accomodated further)

Change-Id: Ia7296c2a0f1e826edc2bc1732db3211298e7bc5d